### PR TITLE
#20 Fixing BQM deserialization

### DIFF
--- a/src/python/zquantum/qubo/io.py
+++ b/src/python/zquantum/qubo/io.py
@@ -49,9 +49,10 @@ def bqm_from_serializable(serializable: Dict[str, Any]) -> dimod.BinaryQuadratic
     Returns:
         Binary quadratic model converted from the input dictionary.
     """
+    safe = lambda i: tuple(i) if type(i) is list else i
     return dimod.BinaryQuadraticModel(
-        {i: coef for i, coef in serializable["linear"]},
-        {(i, j): coef for i, j, coef in serializable["quadratic"]},
+        {safe(i): coef for i, coef in serializable["linear"]},
+        {(safe(i), safe(j)): coef for i, j, coef in serializable["quadratic"]},
         serializable["offset"],
         vartype=serializable["vartype"],
     )

--- a/src/python/zquantum/qubo/io.py
+++ b/src/python/zquantum/qubo/io.py
@@ -49,10 +49,13 @@ def bqm_from_serializable(serializable: Dict[str, Any]) -> dimod.BinaryQuadratic
     Returns:
         Binary quadratic model converted from the input dictionary.
     """
-    safe = lambda i: tuple(i) if type(i) is list else i
+    ensure_hashable = lambda i: tuple(i) if isinstance(i, list) else i
     return dimod.BinaryQuadraticModel(
-        {safe(i): coef for i, coef in serializable["linear"]},
-        {(safe(i), safe(j)): coef for i, j, coef in serializable["quadratic"]},
+        {ensure_hashable(i): coef for i, coef in serializable["linear"]},
+        {
+            (ensure_hashable(i), ensure_hashable(j)): coef
+            for i, j, coef in serializable["quadratic"]
+        },
         serializable["offset"],
         vartype=serializable["vartype"],
     )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -147,6 +147,24 @@ def test_loading_saved_qubo_gives_the_same_qubo():
     assert qubo == new_qubo
 
 
+def test_loading_qubo_with_complex_variables():
+    qubo = dimod.BinaryQuadraticModel(
+        {(0, 0): 1, (1, 0): -1, (2, 0): 0.5},
+        {((0, 0), (1, 0)): 0.5, ((1, 0), (2, 0)): 1.5},
+        42,
+        vartype="SPIN",
+    )
+
+    output_file = StringIO()
+
+    save_qubo(qubo, output_file)
+    # Move to the beginning of the file
+    output_file.seek(0)
+    new_qubo = load_qubo(output_file)
+
+    assert qubo == new_qubo
+
+
 def test_loading_saved_sampleset_gives_the_same_sampleset():
     sampleset = dimod.SampleSet.from_samples(np.ones(5, dtype="int8"), "BINARY", 0)
 


### PR DESCRIPTION
 * addressing #20 
 * serialized BQM accounts for complex variables/labels
 * if `list` encountered as a variable in serialized BQM - it is converted to `tuple` based on assumption that lists can't be dict keys
 * may have value when dealing with BQM's where variables expressed by schema `(Main index, Subindex, ...)`
